### PR TITLE
Add callback for fail-rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -241,14 +241,14 @@ struct SyncCallback {
 }
 
 impl Debug for SyncCallback {
-    fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        Ok(())
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("SyncCallback()")
     }
 }
 
 impl PartialEq for SyncCallback {
-    fn eq(&self, _other: &SyncCallback) -> bool {
-        true
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.callback, &other.callback)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,9 +236,7 @@ use std::{env, thread};
 type Callback = Box<dyn Fn() + Send + Sync>;
 
 #[derive(Clone)]
-struct SyncCallback {
-    callback: Arc<Callback>,
-}
+struct SyncCallback(Arc<Callback>);
 
 impl Debug for SyncCallback {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -248,19 +246,17 @@ impl Debug for SyncCallback {
 
 impl PartialEq for SyncCallback {
     fn eq(&self, other: &Self) -> bool {
-        Arc::ptr_eq(&self.callback, &other.callback)
+        Arc::ptr_eq(&self.0, &other.0)
     }
 }
 
 impl SyncCallback {
     fn new(f: Callback) -> SyncCallback {
-        SyncCallback {
-            callback: Arc::new(f),
-        }
+        SyncCallback(Arc::new(f))
     }
 
     fn run(&self) {
-        let callback = &self.callback;
+        let callback = &self.0;
         callback();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -237,7 +237,7 @@ type Callback = Box<dyn Fn() + Send + Sync>;
 
 #[derive(Clone)]
 struct SyncCallback {
-    callback: Arc<Mutex<Callback>>,
+    callback: Arc<Callback>,
 }
 
 impl Debug for SyncCallback {
@@ -250,21 +250,17 @@ impl PartialEq for SyncCallback {
     fn eq(&self, _other: &SyncCallback) -> bool {
         true
     }
-
-    fn ne(&self, _other: &SyncCallback) -> bool {
-        true
-    }
 }
 
 impl SyncCallback {
     fn new(f: Callback) -> SyncCallback {
         SyncCallback {
-            callback: Arc::new(Mutex::new(f)),
+            callback: Arc::new(f),
         }
     }
 
     fn run(&self) {
-        let callback = self.callback.lock().unwrap();
+        let callback = &self.callback;
         callback();
     }
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -148,12 +148,9 @@ fn test_callback() {
 
     let counter = Arc::new(AtomicUsize::new(0));
     let counter2 = counter.clone();
-    fail::cfg_callback(
-        "cb",
-        Box::new(move || {
-            counter2.fetch_add(1, Ordering::SeqCst);
-        }),
-    )
+    fail::cfg_callback("cb", move || {
+        counter2.fetch_add(1, Ordering::SeqCst);
+    })
     .unwrap();
     f1();
     f2();

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -107,7 +107,7 @@ fn test_pause() {
 
     fail::cfg("pause", "pause").unwrap();
     let (tx, rx) = mpsc::channel();
-    std::thread::spawn(move || {
+    thread::spawn(move || {
         // pause
         tx.send(f()).unwrap();
         // woken up by new order pause, and then pause again.
@@ -139,7 +139,10 @@ fn test_yield() {
 #[test]
 #[cfg_attr(not(feature = "failpoints"), ignore)]
 fn test_callback() {
-    let f = || {
+    let f1 = || {
+        fail_point!("cb");
+    };
+    let f2 = || {
         fail_point!("cb");
     };
 
@@ -152,8 +155,9 @@ fn test_callback() {
         }),
     )
     .unwrap();
-    f();
-    assert_eq!(1, counter.load(Ordering::SeqCst));
+    f1();
+    f2();
+    assert_eq!(2, counter.load(Ordering::SeqCst));
 }
 
 #[test]


### PR DESCRIPTION
Signed-off-by: Little-Wallace <bupt2013211450@gmail.com>

I want to add a new kind of action for `fail-rs`, which can help TiKV be able to stop at some statement and call one `callback` function that set by tests. This feature will help use more convenient to deal with some tests which need to wait for a while, because we can pass a callback to `fail_point` to notify test-thread to avoid waiting.