### PR TITLE
bump deps and make clippy happy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ exclude = ["/.github/*", "/.travis.yml", "/appveyor.yml"]
 
 [dependencies]
 log = { version = "0.4", features = ["std"] }
-lazy_static = "1.2"
-rand = "0.7"
+lazy_static = "1.4"
+rand = "0.8"
 
 [features]
 failpoints = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = ["/.github/*", "/.travis.yml", "/appveyor.yml"]
 
 [dependencies]
 log = { version = "0.4", features = ["std"] }
-lazy_static = "1.4"
+lazy_static = "1.2"
 rand = "0.8"
 
 [features]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -243,10 +243,9 @@ impl Debug for SyncCallback {
     }
 }
 
-#[allow(clippy::vtable_address_comparisons)]
 impl PartialEq for SyncCallback {
-    fn eq(&self, other: &Self) -> bool {
-        Arc::ptr_eq(&self.0, &other.0)
+    fn eq(&self, _: &Self) -> bool {
+        unimplemented!()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -244,11 +244,9 @@ impl Debug for SyncCallback {
 }
 
 impl PartialEq for SyncCallback {
+    #[allow(clippy::vtable_address_comparisons)]
     fn eq(&self, other: &Self) -> bool {
-        std::ptr::eq(
-            &*self.0 as *const (dyn Fn() + Send + Sync) as *const u8,
-            &*other.0 as *const (dyn Fn() + Send + Sync) as *const u8,
-        )
+        Arc::ptr_eq(&self.0, &other.0)
     }
 }
 


### PR DESCRIPTION
- rand 0.8
- unimpl PartialEq for SyncCallback, because of `#[deny(clippy::vtable_address_comparisons)]`
- `compare_and_swap` -> `compare_exchange`, because of `#[warn(deprecated)]`