### PR TITLE
2021 edition & once cell

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/tikv/fail-rs"
 documentation = "https://docs.rs/fail"
 description = "Fail points for rust."
 categories = ["development-tools::testing"]
-edition = "2018"
+edition = "2021"
 exclude = ["/.github/*", "/.travis.yml", "/appveyor.yml"]
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = ["/.github/*", "/.travis.yml", "/appveyor.yml"]
 
 [dependencies]
 log = { version = "0.4", features = ["std"] }
-lazy_static = "1.2"
+once_cell = "1.9.0"
 rand = "0.8"
 
 [features]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -523,10 +523,10 @@ struct FailPointRegistry {
     registry: RwLock<Registry>,
 }
 
-lazy_static::lazy_static! {
-    static ref REGISTRY: FailPointRegistry = FailPointRegistry::default();
-    static ref SCENARIO: Mutex<&'static FailPointRegistry> = Mutex::new(&REGISTRY);
-}
+use once_cell::sync::Lazy;
+
+static REGISTRY: Lazy<FailPointRegistry> = Lazy::new(FailPointRegistry::default);
+static SCENARIO: Lazy<Mutex<&'static FailPointRegistry>> = Lazy::new(|| Mutex::new(&REGISTRY));
 
 /// Test scenario with configured fail points.
 #[derive(Debug)]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -109,23 +109,14 @@ fn test_pause() {
     let (tx, rx) = mpsc::channel();
     thread::spawn(move || {
         // pause
-        {
-            f();
-            tx.send(())
-        }
-        .unwrap();
+        f();
+        tx.send(()).unwrap();
         // woken up by new order pause, and then pause again.
-        {
-            f();
-            tx.send(())
-        }
-        .unwrap();
+        f();
+        tx.send(()).unwrap();
         // woken up by remove, and then quit immediately.
-        {
-            f();
-            tx.send(())
-        }
-        .unwrap();
+        f();
+        tx.send(()).unwrap();
     });
 
     assert!(rx.recv_timeout(Duration::from_millis(500)).is_err());

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -109,11 +109,23 @@ fn test_pause() {
     let (tx, rx) = mpsc::channel();
     thread::spawn(move || {
         // pause
-        tx.send(f()).unwrap();
+        {
+            f();
+            tx.send(())
+        }
+        .unwrap();
         // woken up by new order pause, and then pause again.
-        tx.send(f()).unwrap();
+        {
+            f();
+            tx.send(())
+        }
+        .unwrap();
         // woken up by remove, and then quit immediately.
-        tx.send(f()).unwrap();
+        {
+            f();
+            tx.send(())
+        }
+        .unwrap();
     });
 
     assert!(rx.recv_timeout(Duration::from_millis(500)).is_err());


### PR DESCRIPTION
- rust 2021 edition
- replace lazy_static with once_cell
  - macro-free
  - active & popular