### PR TITLE
*: bump 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.5.1 - 2022-10-08
+
+- Switch to 2021 edition and use once cell (#61)
+- Support configuring fail point in RAII style (#62)
+- Fix recursive macro invocation (#66)
+
 # 0.5.0 - 2021-11-04
 
 - update rand to 0.8

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fail"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["The TiKV Project Developers"]
 license = "Apache-2.0"
 keywords = ["failpoints", "fail"]


### PR DESCRIPTION
Although some change replace lazy_static with once_cell, but Cargo should resolve different minor versions into single one, so bumping minor version should be enough.