### PR TITLE
Fix typo'd env var name in docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@
 //!
 //! ## Usage in tests
 //!
-//! The previous example triggers a fail point by modifying the `FAILPOINT`
+//! The previous example triggers a fail point by modifying the `FAILPOINTS`
 //! environment variable. In practice, you'll often want to trigger fail points
 //! programmatically, in unit tests.
 //! Fail points are global resources, and Rust tests run in parallel,


### PR DESCRIPTION
---
name: Fix env var name in docs
about: A bug squashed.

---

**Related bugs:**
n/a

**Description of problem:**
When reading the docs I was briefly confused what the correct variable name was.1

**Description of solution:**
Fix the docs to match the code.

Also, update a renamed Clippy lint, so that CI doesn't fail.

**Checklist:**
The CI will check all of these, but you'll need to have done them:

* [x] `cargo fmt -- --check` passes.
* [ ] `cargo +nightly clippy` has no warnings.
* [x] `cargo test` passes.
