### PR TITLE
Fix FAILPOINTS variable name in docs, and lints

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -244,7 +244,6 @@ impl Debug for SyncCallback {
 }
 
 impl PartialEq for SyncCallback {
-    #[allow(ambiguous_wide_pointer_comparisons)]
     fn eq(&self, other: &Self) -> bool {
         Arc::ptr_eq(&self.0, &other.0)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -244,7 +244,7 @@ impl Debug for SyncCallback {
 }
 
 impl PartialEq for SyncCallback {
-    #[allow(clippy::vtable_address_comparisons)]
+    #[allow(ambiguous_wide_pointer_comparisons)]
     fn eq(&self, other: &Self) -> bool {
         Arc::ptr_eq(&self.0, &other.0)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@
 //!
 //! Here's a basic pattern for writing unit tests tests with fail points:
 //!
-//! ```rust
+//! ```rust,no_run
 //! use fail::{fail_point, FailScenario};
 //!
 //! fn do_fallible_work() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@
 //!
 //! ## Usage in tests
 //!
-//! The previous example triggers a fail point by modifying the `FAILPOINT`
+//! The previous example triggers a fail point by modifying the `FAILPOINTS`
 //! environment variable. In practice, you'll often want to trigger fail points
 //! programmatically, in unit tests.
 //! Fail points are global resources, and Rust tests run in parallel,


### PR DESCRIPTION
---
name: Fix env var name in docs
about: A bug squashed.

---

**Related bugs:**
n/a

**Description of problem:**
When reading the docs I was briefly confused what the correct variable name was.1

**Description of solution:**
Fix the docs to match the code.

Also, since rustc warns that unit tests inside docests are not run, mark it as `norun` for clarity and to address a warning.

**Checklist:**
The CI will check all of these, but you'll need to have done them:

* [x] `cargo fmt -- --check` passes.
* [x] `cargo +nightly clippy` has no warnings.
* [x] `cargo test` passes.
